### PR TITLE
chore: 组件加载时新增加载状态

### DIFF
--- a/src/apiView/RequestContent/modules/DynamicKVForm.vue
+++ b/src/apiView/RequestContent/modules/DynamicKVForm.vue
@@ -130,7 +130,7 @@ watch(
     &:hover {
       scale: 1.2;
     }
-    transition: transform 1s scale;
+    transition: transform 1s ease-in-out;
   }
 }
 </style>

--- a/src/designer/load.ts
+++ b/src/designer/load.ts
@@ -1,3 +1,4 @@
+import { NSpin } from 'naive-ui'
 import type { App } from 'vue'
 import { defineAsyncComponent } from 'vue'
 
@@ -12,7 +13,16 @@ const AsyncComponent = {
   install: (app: App) => {
     // 注册Group组件
     componentList[Group.componentName] = Group.config
-    const AsyncComp = defineAsyncComponent(Group.component)
+    const AsyncComp = defineAsyncComponent({
+      loader: Group.component,
+      // 加载异步组件时使用的组件
+      loadingComponent: NSpin,
+      // 展示加载组件前的延迟时间，默认为 200ms
+      delay: 200,
+      // 如果提供了一个 timeout 时间限制，并超时了
+      // 也会显示这里配置的报错组件，默认值是：Infinity
+      timeout: 3000
+    })
     app.component(Group.componentName, AsyncComp)
 
     const moduleFilesTs: any = import.meta.glob('../resource/components/**/index.ts', {

--- a/src/designer/modules/ruler/sketch-ruler/RulerLine.vue
+++ b/src/designer/modules/ruler/sketch-ruler/RulerLine.vue
@@ -110,7 +110,7 @@ const contextmenus = (): ContextmenuItem[] => {
     pointer-events: none;
     mix-blend-mode: difference;
     &:hover {
-      backgourd-color: yellow;
+      background-color: yellow;
     }
   }
   .is-vertical {

--- a/src/designer/pages/designer/Canvas.vue
+++ b/src/designer/pages/designer/Canvas.vue
@@ -10,7 +10,7 @@
       <n-space justify="end" align="center" style="height: 100%; margin-right: 5px">
         <n-el
           tag="span"
-          style="color: var(--primary-color); transition: 0.3s var(--cubic-bezier-ease-in-out)"
+          :style="{ color: primaryColor, transition: `all 0.3s ${cubicBezierEaseInOut}` }"
         >
           画布缩放:
         </n-el>
@@ -44,7 +44,8 @@ import {
   NScrollbar,
   NSelect,
   NSlider,
-  NSpace
+  NSpace,
+  useThemeVars
 } from 'naive-ui'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
@@ -82,6 +83,9 @@ const options: SelectOption[] = [
     label: '50%'
   }
 ]
+
+const themeVars = useThemeVars()
+const { primaryColor, cubicBezierEaseInOut } = themeVars.value
 
 const scrollbarStyle = computed(() => {
   return {


### PR DESCRIPTION
1. 加载状态组件可以在 `src/design/load` 中的 `loadingComponent` 替换
2. 默认加载组件前的延时为 `200ms`
3. 加载时间默认超过 `3000ms` 为失败，最高超时时间可设置为 `Infinity`
详情设置请看 [vue - 异步组件](https://cn.vuejs.org/guide/components/async.html#basic-usage)
4. 修复部分拼写错误，`Canvas.vue` 中颜色变量使用组件官方 hooks