### PR TITLE
fix: 修复调整组件属性时，其他组件属性被异常同步问题

### DIFF
--- a/src/designer/modules/form/FormAttr.tsx
+++ b/src/designer/modules/form/FormAttr.tsx
@@ -15,7 +15,7 @@ import {
   NSwitch
 } from 'naive-ui'
 import type { PropType } from 'vue'
-import { defineComponent, h, reactive, ref } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 
 import { FormType, GlobalColorSwatches } from '@/enum'
 import type {
@@ -69,7 +69,6 @@ export default defineComponent({
   },
   emits: ['change'],
   setup(props, { emit }) {
-    const formData = reactive<Recordable>(props.data)
     const changed = (val: any, keys: Array<string>) => {
       emit('change', keys, val)
     }
@@ -279,7 +278,7 @@ export default defineComponent({
             label={item.label}
             showLabel={isShowLabel(item.showLabel)}
           >
-            {isUndefined(formData) ? <></> : renderItem(item, formData, [props.uid])}
+            {isUndefined(props.data) ? <></> : renderItem(item, props.data, [props.uid])}
           </NFormItem>
         ))}
       </NForm>


### PR DESCRIPTION
复现步骤：
以边框#2 组件举例
1. 拖动边框组件到画布，选中
2. 再次拖动边框组件到画布，选中，并修改当前组件属性
3. 发现两个组件属性同时修改


https://github.com/AnsGoo/openDataV/assets/16788862/8b12749e-2c35-449a-b3a0-510f8b840a8e

